### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # Azure MCP Server
 
+[![smithery badge](https://smithery.ai/badge/@mashriram/azure_mcp_server)](https://smithery.ai/server/@mashriram/azure_mcp_server)
+
 An implementation of a [Model Context Protocol](https://www.anthropic.com/news/model-context-protocol) server for interacting with Azure services. Currently supports Azure Blob Storage and Azure Cosmos DB (NoSQL API). All operations performed through this server are automatically logged and accessible via the `audit://azure-operations` resource endpoint.
 
 ## Running Locally with the Claude Desktop App
+
+### Installing via Smithery
+
+To install Azure MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@mashriram/azure_mcp_server):
+
+```bash
+npx -y @smithery/cli install @mashriram/azure_mcp_server --client claude
+```
 
 ### Manual Installation
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,25 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - azureStorageAccountUrl
+      - azureCosmosDbEndpoint
+      - azureCosmosDbKey
+    properties:
+      azureStorageAccountUrl:
+        type: string
+        description: The URL of your Azure Storage account.
+      azureCosmosDbEndpoint:
+        type: string
+        description: The endpoint URL for your Azure Cosmos DB account.
+      azureCosmosDbKey:
+        type: string
+        description: The primary or secondary key for your Azure Cosmos DB account.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({command: 'hatch', args: ['run', 'mcp_server_azure_cmd'], env: { AZURE_STORAGE_ACCOUNT_URL: config.azureStorageAccountUrl, AZURE_COSMOSDB_ENDPOINT: config.azureCosmosDbEndpoint, AZURE_COSMOSDB_KEY: config.azureCosmosDbKey }})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@mashriram/azure_mcp_server?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂